### PR TITLE
This is an edit to the minecraft-init version command, which pulls from ...

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -479,7 +479,8 @@ case "$1" in
 		fi
 		;;
 	version)
-		echo Craftbukkit version `awk '/Craftbukkit/ {sub(/\)/, ""); print $12}' $MCPATH/server.log`
+		as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"version\"\015'"
+		tac $MCPATH/server.log | grep -m 1 "This server is running"
 		;;
 	links)
 		check_links


### PR DESCRIPTION
...the server.log the version command ran on the server console.

The resulting text shows exactly what bukkit spits out as it's version:

[INFO] This server is running CraftBukkit version git-Bukkit-1.1-R4-b1938jnks (MC: 1.1) (Implementing API version 1.1-R4)

This is what i believe was intended by the Ahtenus, but was not function as of Bukkit 1.1-R4.
