### PR TITLE
Add support for specifying user's shell

### DIFF
--- a/config.example
+++ b/config.example
@@ -20,6 +20,8 @@ CB_RELEASE="stable"
 SCREEN="minecraft"
 # User that should run the server
 USERNAME="v"
+# Shell user should run the server with
+USERSHELL="/bin/sh"
 # Path to minecraft directory 
 MCPATH="/home/${USERNAME}/minecraft"
 # Number of CPUs/cores to use

--- a/minecraft
+++ b/minecraft
@@ -42,7 +42,7 @@ as_user() {
 	if [ $ME == $USERNAME ] ; then
 		bash -c "$1"
 	else
-		su - $USERNAME -c "$1"
+		su - $USERNAME -s $USERSHELL -c "$1"
 	fi
 }
 error_if_running() {


### PR DESCRIPTION
When the user configured to run minecraft is not assigned a shell,
minecraft will fail to start. By specifying the shell to use in
the config file, this is no longer an issue.
