### PR TITLE
Added "say" command to the minecraft utility. This prints the given string to the in-game chat.

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -116,6 +116,16 @@ mc_saveon() {
 	fi
 }
 
+mc_say() {
+	if is_running
+	then
+		echo "Said: $1"
+		as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"say $1\"\015'"
+	else
+		echo "$SERVICE was not running. Not able to say anything."
+	fi
+}
+
 mc_stop() {
 	#
 	# Stops the server
@@ -482,6 +492,14 @@ case "$1" in
 			echo "No running server."
 		fi
 		;;
+	say)
+		# Says something to the ingame chat
+		if is_running; then
+			mc_say "$2"
+		else
+			echo "No running server to say anything."
+		fi
+		;;
 	connected)
 		# Lists connected users
 		if is_running; then
@@ -562,6 +580,7 @@ case "$1" in
 		echo "to-disk - copies the worlds from the ramdisk to worldstorage"
 		echo "save-off - flushes the world to disk and then disables saving until save-on is called"
 		echo "save-on - re-enables saving if it was previously disabled by save-off"
+		echo "say - Prints the given string to the ingame chat."
 		echo "connected - lists connected users"
 		echo "status - Shows server status"
 		echo "version - returs Bukkit version"


### PR DESCRIPTION
By utilizing the same method as is used in many other parts of the utility, this modification allows a user to print text to the in-game chat from outside the screen session.  This is done in a similar way to how other operations are preformed such as the saveon and saveoff commands: it opens the screen session and evaluates a string into the standard input stream of the minecraft server.

This is useful to add customization to many automated systems.  Without customization of the script itself, it is possible to alert users to what is going on in the server.  (Is the server being restarted? map switched? temporarily down?).  Most importantly, it lets admins administrate without having to open up a pesky screen session, (something that makes remote administration without a terminal possible).
