### PR TITLE
Backups Script Compatibility Improvements and Bug Fixes

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -203,6 +203,10 @@ mc_world_backup() {
 
 	get_worlds
 	today="`date +%F`"
+		if [ "$BACKUPSCRIPTCOMPATIBLE" ]
+		then
+			as_user "rm -r $BACKUPPATH/*"
+		fi
 	for INDEX in ${!WORLDNAME[@]}
 	do
 		echo "Backing up minecraft ${WORLDNAME[$INDEX]}"

--- a/minecraft
+++ b/minecraft
@@ -203,6 +203,7 @@ mc_world_backup() {
 
 	get_worlds
 	today="`date +%F`"
+	as_user "mkdir -p $BACKUPPATH"
 	# Check if the backupt script compatibility is enabled
 		if [ "$BACKUPSCRIPTCOMPATIBLE" ]
 		then

--- a/minecraft
+++ b/minecraft
@@ -203,8 +203,10 @@ mc_world_backup() {
 
 	get_worlds
 	today="`date +%F`"
+	# Check if the backupt script compatibility is enabled
 		if [ "$BACKUPSCRIPTCOMPATIBLE" ]
 		then
+			echo "Detected that backup script compatibility is enabled, deleting old backups that are not necessary."
 			as_user "rm -r $BACKUPPATH/*"
 		fi
 	for INDEX in ${!WORLDNAME[@]}
@@ -216,8 +218,6 @@ mc_world_backup() {
 				# If is set tars will be put in $BACKUPPATH without any timestamp to be compatible with
 				# [backup rotation script](https://github.com/adamfeuer/rotate-backups)
 				then
-					echo "Deleting old backup of ${WORLDNAME[$INDEX]}"
-					as_user "rm -r $BACKUPPATH/${WORLDNAME[$INDEX]}.zip"
 					path=$BACKUPPATH/${WORLDNAME[$INDEX]}.tar.bz2
 				else
 					as_user "mkdir -p $BACKUPPATH/${today}"
@@ -228,8 +228,6 @@ mc_world_backup() {
 			zip)
 				if [ "$BACKUPSCRIPTCOMPATIBLE" ]
 				then
-					echo "Deleting old backup of ${WORLDNAME[$INDEX]}"
-					as_user "rm -r $BACKUPPATH/${WORLDNAME[$INDEX]}.zip"
 					path=$BACKUPPATH/${WORLDNAME[$INDEX]}.zip
 				else
 					as_user "mkdir -p $BACKUPPATH/${today}"


### PR DESCRIPTION
I improved the old system of removing backups. The old system if it is going to backup a world file called world, it removes only world.zip or world.tar.gz. This new system removes everything else in the backups folder before it is backed up. This is safe since it only does this if the backup script compatibility is enabled in the config, which, if it is, would mean that the backup script would roll backups before it erases them. This is why it is OK to do it, as the backup rolling script will remove them anyway. The reason why I don't let the backup rolling script remove them is cause if there is a foreign file, such as a half-completed backup or the like, it will roll it into a new folder, which is annoying. Unfortunately, the old system didn't fix this, it was only a partial fix for the problem. This improved system is more reliable and safer and it doesn't risk leaving pesky files and folder randomly lying around. Please take a look at my 2 commits if you want to, and although I have already tested it, feel free to test it yourself to make sure that it works properly for you too.
