### PR TITLE
Render with lower priority

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -398,9 +398,11 @@ overviewer_start() {
                         echo "Start generating map with Minecraft-Overviewer"
                         if [ "$OVPATH" == "apt" ]
                         then
-                                as_user "overviewer.py $OVBACKUP/$1 $OUTPUTMAP"
+                                #as_user "overviewer.py --genpoi $OVBACKUP/$1 $OUTPUTMAP"
+                                as_user "nice overviewer.py $OVBACKUP/$1 $OUTPUTMAP"
                         else
-                                as_user "python $OVPATH/overviewer.py $OVBACKUP/$1 $OUTPUTMAP"
+                                #as_user "python $OVPATH/overviewer.py --genpoi $OVBACKUP/$1 $OUTPUTMAP"
+                                as_user "nice python $OVPATH/overviewer.py $OVBACKUP/$1 $OUTPUTMAP"
                         fi
                         echo "Map generated"
                 fi


### PR DESCRIPTION
This change set ensures that Map-Generation with Minecraft-Overviewer runs with lower priority than the main mine craft server. Helps to keep mine craft running smooth on resource constrained machines.
