### PR TITLE
Spelling and grammar corrections

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -238,7 +238,7 @@ mc_world_backup() {
 				as_user "zip -rq $path $MCPATH/${WORLDNAME[$INDEX]}"
 				;;
 			*)
-				echo "$BACKUPFORMAT is no supported backup format"
+				echo "$BACKUPFORMAT is not a supported backup format"
 				;;
 		esac
 	done
@@ -256,18 +256,18 @@ check_links() {
 				then
 					as_user "rm -f $MCPATH/${WORLDNAME[$INDEX]}"
 					as_user "ln -s $RAMDISK/${WORLDNAME[$INDEX]} $MCPATH/${WORLDNAME[$INDEX]}"
-					echo "created link for ${WORLDNAME[$INDEX]}"
+					echo "Created link for ${WORLDNAME[$INDEX]}"
 				fi
 			else
 				if [ "$link" != "${WORLDSTORAGE}/${WORLDNAME[$INDEX]}" ]
 				then
 					as_user "rm -f $MCPATH/${WORLDNAME[$INDEX]}"
 					as_user "ln -s ${WORLDSTORAGE}/${WORLDNAME[$INDEX]} $MCPATH/${WORLDNAME[$INDEX]}"
-					echo "created link for ${WORLDNAME[$INDEX]}"
+					echo "Created link for ${WORLDNAME[$INDEX]}"
 				fi
 			fi
 		else
-			echo "could not process ${WORLDNAME[$INDEX]}. please move all worlds to ${WORLDSTORAGE}."
+			echo "Could not process ${WORLDNAME[$INDEX]}. please move all worlds to ${WORLDSTORAGE}."
 			exit 1
 		fi
 	done
@@ -382,28 +382,28 @@ overviewer_start() {
         fi
         if [ -e $OVCONFIGPATH/$OVCONFIGNAME ]
         then
-                echo "Start generating map with Minecraft-Overviewer"
+                echo "Start generating map with Minecraft-Overviewer..."
                 if [ "$OVPATH" == "apt" ]
                 then
                         as_user "overviewer.py --config=$OVCONFIGPATH/$OVCONFIGNAME"
                 else
                         as_user "python $OVPATH/overviewer.py --config=$OVCONFIGPATH/$OVCONFIGNAME"
                 fi
-                echo "Map generated"
+                echo "Map generated."
         else
-                echo "No config file found. Start with default config"
+                echo "No config file found. Start with default config..."
                 if [ -z $1 ] || [ ! -e $OVBACKUP/$1 ]
                 then
                         echo "World \"$1\" not found."
                 else
-                        echo "Start generating map with Minecraft-Overviewer"
+                        echo "Start generating map with Minecraft-Overviewer..."
                         if [ "$OVPATH" == "apt" ]
                         then
                                 as_user "nice overviewer.py $OVBACKUP/$1 $OUTPUTMAP"
                         else
                                 as_user "nice python $OVPATH/overviewer.py $OVBACKUP/$1 $OUTPUTMAP"
                         fi
-                        echo "Map generated"
+                        echo "Map generated."
                 fi
         fi
 }
@@ -416,7 +416,7 @@ overviewer_copy_worlds() {
 	get_worlds
 	for INDEX in ${!WORLDNAME[@]}
 	do
-		echo "Copying minecraft ${WORLDNAME[$INDEX]}"
+		echo "Copying minecraft ${WORLDNAME[$INDEX]}."
 		as_user "mkdir -p $OVBACKUP"
 		as_user "rsync -rt --delete $WORLDSTORAGE/${WORLDNAME[$INDEX]} $OVBACKUP/${WORLDNAME[$INDEX]}"
 	done
@@ -442,13 +442,13 @@ case "$1" in
 			mc_stop
 			to_disk
 		else
-			echo "No running server"
+			echo "No running server."
 		fi
 		;;
 	restart)
 		# Restarts the server
 		if is_running; then
-			as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"say SERVER REBOOT IN 10 SECONDS.\"\015'"
+			as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"say SERVER REBOOT IN 10 SECONDS!\"\015'"
 			mc_stop
 			to_disk
 		else
@@ -463,7 +463,7 @@ case "$1" in
 		if is_running; then
 			as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"whitelist reload\"\015'"
 		else
-			echo "No running server"
+			echo "No running server."
 		fi
 		;;
 	whitelist-add)
@@ -471,7 +471,7 @@ case "$1" in
 		if is_running; then
 			as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"whitelist add $2\"\015'"
 		else
-			echo "No running server"
+			echo "No running server."
 		fi
 		;;
 	backup)

--- a/minecraft
+++ b/minecraft
@@ -477,7 +477,7 @@ case "$1" in
 	backup)
 		# Backups world
 		if is_running; then
-			as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"say Backing up world.\"\015'"
+			as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"say Backing up world, brace for lag.\"\015'"
 			mc_saveoff
 			to_disk
 			mc_world_backup
@@ -490,7 +490,8 @@ case "$1" in
 	whole-backup)
                 # Backup everything
 		if is_running; then
-			as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"say SERVER WHOLE-BACKUP IN 10 SECONDS.\"\015'"
+			as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"say COMPLETE SERVER BACKUP IN 10 SECONDS.\"\015'"
+			as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"say WARNING: WILL RESTART SERVER SOFTWARE!\"\015'"
 			mc_stop
 			to_disk
 			mc_whole_backup
@@ -604,7 +605,7 @@ case "$1" in
 		;;
 	overviewer)
 		if is_running; then
-			as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"say MAP OVERVIEW GENERATING!\"\015'"
+			as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"say MAP OVERVIEW GENERATING, PREPARE FOR LAG!\"\015'"
 			mc_saveoff
 			to_disk
 			overviewer_copy_worlds

--- a/minecraft
+++ b/minecraft
@@ -78,7 +78,7 @@ mc_start() {
 	seconds=0
 	until ps ax | grep -v grep | grep -v -i SCREEN | grep $SERVICE > /dev/null
 	do
-		sleep 1 
+		sleep 1
 		seconds=$seconds+1
 		if [[ $seconds -eq 5 ]]
 		then

--- a/minecraft
+++ b/minecraft
@@ -207,6 +207,7 @@ mc_world_backup() {
 	# Check if the backupt script compatibility is enabled
 		if [ "$BACKUPSCRIPTCOMPATIBLE" ]
 		then
+			# If it is enabled, then delete the old backups to prevent errors
 			echo "Detected that backup script compatibility is enabled, deleting old backups that are not necessary."
 			as_user "rm -r $BACKUPPATH/*"
 		fi
@@ -301,7 +302,7 @@ mc_update() {
 	then
 		echo "$SERVICE is running! Will not start update."
 	else
-		### update minecraft_server.jar
+		# Update minecraft_server.jar
 		echo "Updating minecraft_server.jar...."
 		MC_SERVER_URL=`wget -q -O - http://www.minecraft.net/download | grep minecraft_server.jar\  | cut -d \" -f 6`
 		as_user "cd $MCPATH && wget -q -O $MCPATH/minecraft_server.jar.update $MC_SERVER_URL"
@@ -319,7 +320,7 @@ mc_update() {
 			echo "Minecraft update could not be downloaded."
 		fi
 
-		### update craftbukkit
+		# Update craftbukkit.jar
 		echo "Updating craftbukkit...."
 		case $CB_RELEASE in
 			unstable|UNSTABLE|Unstable|dev|development)


### PR DESCRIPTION
I've corrected some minor spelling and grammar errors in the commenting and commands that display to the console and players on the server. Mostly capitalizing the first letter of sentences, but I also added another line that reminds the user that the server will restart, and the backup and overviewer commands now tell all online players that the server will lag.
