### PR TITLE
Change the "whole-backup" from cp to tar

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -201,9 +201,9 @@ get_worlds() {
 }
 mc_whole_backup() {
 	echo "backing up entire setup into $WHOLEBACKUP"
-	as_user "mkdir -p $WHOLEBACKUP"
 	path=`datepath $WHOLEBACKUP/mine_`
-	as_user "cp -rP $MCPATH $path"
+	as_user "mkdir -p $path"
+	as_user "tar -cf $path/whole-backup.tar $MCPATH"
 }
 mc_world_backup() {
 	#


### PR DESCRIPTION
I prefer backing up the whole server installation with `tar` instead of `cp` since this is **way** faster then `cp`, especially, when the server ist using dynmap, that has lots of small files in its directories.
