### PR TITLE
Exclude files and / or dirs from full backup

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -193,6 +193,7 @@ get_worlds() {
 			then
 				WORLDRAM[$a]=true
 			else
+				WORLDRAM[$a]=false
 			fi
 			a=$a+1
 		fi

--- a/minecraft
+++ b/minecraft
@@ -193,7 +193,6 @@ get_worlds() {
 			then
 				WORLDRAM[$a]=true
 			else
-				WORLDRAM[$a]=false
 			fi
 			a=$a+1
 		fi
@@ -202,13 +201,27 @@ get_worlds() {
 mc_whole_backup() {
 	echo "backing up entire setup into $WHOLEBACKUP"
 	path=`datepath $WHOLEBACKUP/mine_`
+	locationOfScript=$(dirname "$(readlink -e "$0")")
 	as_user "mkdir -p $path"
 	
-	if [ "$COMPRESS_WHOLEBACKUP" ]
+	if [ -r "$locationOfScript/exclude.list" ]
 	then
-		as_user "tar -cpjf $path/whole-backup.tar.bz2 $MCPATH"
+		echo "...except the following files and/or dirs:"
+		cat $locationOfScript/exclude.list
+		
+		if [ "$COMPRESS_WHOLEBACKUP" ]
+		then
+			as_user "tar -cpjf $path/whole-backup.tar.bz2 $MCPATH -X $locationOfScript/exclude.list"
+		else
+			as_user "tar -cpf $path/whole-backup.tar $MCPATH -X $locationOfScript/exclude.list"
+		fi
 	else
-		as_user "tar -cpf $path/whole-backup.tar $MCPATH"
+		if [ "$COMPRESS_WHOLEBACKUP" ]
+		then
+			as_user "tar -cpjf $path/whole-backup.tar.bz2 $MCPATH"
+		else
+			as_user "tar -cpf $path/whole-backup.tar $MCPATH"
+		fi
 	fi
 }
 mc_world_backup() {

--- a/readme.markdown
+++ b/readme.markdown
@@ -10,6 +10,7 @@ Features
  * Cleaning of server.log, a big log file slows down the server
  * Backup for worlds
  * Server updating and complete backup
+ * Exclude files and directories from full backup by adding them to "exclude.list"
 
 Requirements
 ------------


### PR DESCRIPTION
These changes use the -X parameter of tar to provide a way to exclude files and directories from "whole backup" by adding them to the file "exclude.list".

It also checks, if the file is actually readable to avoid errors during the backup.
