### PR TITLE
Change field separator to fix #85

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -183,6 +183,9 @@ log_roll() {
 
 }
 get_worlds() {
+	SAVEIFS=$IFS
+	$IFS=$(echo -en "\n\b")
+
 	a=1
 	for NAME in $(ls $WORLDSTORAGE)
 	do
@@ -198,6 +201,8 @@ get_worlds() {
 			a=$a+1
 		fi
 	done
+
+	IFS=$SAVEIFS
 }
 mc_whole_backup() {
 	echo "backing up entire setup into $WHOLEBACKUP"

--- a/minecraft
+++ b/minecraft
@@ -184,7 +184,7 @@ log_roll() {
 }
 get_worlds() {
 	SAVEIFS=$IFS
-	$IFS=$(echo -en "\n\b")
+	IFS=$(echo -en "\n\b")
 
 	a=1
 	for NAME in $(ls $WORLDSTORAGE)


### PR DESCRIPTION
The function get_worlds() fails with worlds, that have spaces in their names. I fixed this by changing the field separator.

Fixes: #85
