### PR TITLE
Pidfile

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -48,11 +48,32 @@ as_user() {
 is_running(){
 	# Checks for the minecraft servers screen session
 	# returns true if it exists.
-	if ps ax | grep -v grep | grep "$SCREEN $INVOCATION" > /dev/null
+	pidfile=$(get_script_location)/${SCREEN}.pid
+
+	if [ -r "$pidfile" ]
 	then
-		return 0
+		pid=$(cat $pidfile)
+		if ps ax | grep -v grep | grep ${pid} | grep "${SCREEN} ${INVOCATION}" > /dev/null
+		then
+			return 0
+		else 
+			echo "Rogue pidfile found!"
+			return 1
+		fi
+	else
+		if ps ax | grep -v grep | grep "$SCREEN $INVOCATION" > /dev/null
+		then
+			echo "No pidfile found, but server's running."
+			echo "Re-creating the pidfile."
+			
+			pid=$(ps ax | grep -v grep | grep "${SCREEN} ${INVOCATION}" | cut -f1 -d' ')
+			echo $pid > $pidfile
+
+			return 0
+		else
+			return 1
+		fi
 	fi
-	return 1
 }
 datepath() {
 	# datepath path filending-to-check returned-filending
@@ -70,13 +91,16 @@ datepath() {
 	fi
 }
 mc_start() {
-	cd $MCPATH
+	pidfile=$(get_script_location)/${SCREEN}.pid
+
 	as_user "cd $MCPATH && screen -dmS $SCREEN $INVOCATION"
+	as_user "echo $(screen -list | grep $SCREEN | cut -f1 -d'.' | sed 's/\W//g') > $pidfile"
+
 	#
 	# Waiting for the server to start
 	#
 	seconds=0
-	until ps ax | grep -v grep | grep -v -i SCREEN | grep $SERVICE > /dev/null
+	until is_running 
 	do
 		sleep 1
 		seconds=$seconds+1
@@ -136,6 +160,7 @@ mc_say() {
 }
 
 mc_stop() {
+	pidfile=$(get_script_location)/${SCREEN}.pid
 	#
 	# Stops the server
 	#
@@ -149,7 +174,7 @@ mc_stop() {
 	# Waiting for the server to shut down
 	#
 	seconds=0
-	while ps ax | grep -v grep | grep -v -i SCREEN | grep $SERVICE > /dev/null
+	while is_running
 	do
 		sleep 1 
 		seconds=$seconds+1
@@ -163,7 +188,8 @@ mc_stop() {
 			echo "Failed to shut down, aborting."
 			exit 1
 		fi
-	done	
+	done
+	as_user "rm $pidfile"
 	echo "$SERVICE is now shut down."
 }
 log_roll() {
@@ -438,6 +464,10 @@ overviewer_copy_worlds() {
 		as_user "mkdir -p $OVBACKUP"
 		as_user "rsync -rt --delete $WORLDSTORAGE/${WORLDNAME[$INDEX]} $OVBACKUP/${WORLDNAME[$INDEX]}"
 	done
+}
+
+get_script_location() {
+	echo $(dirname "$(readlink -e "$0")")
 }
 
 

--- a/minecraft
+++ b/minecraft
@@ -525,22 +525,19 @@ overviewer_copy_worlds() {
 	done
 }
 
-<<<<<<< HEAD
 whitelist(){
 	mc_command "whitelist list"
 	sleep 1s
 	whitelist=$(tac $MCPATH/server.log | grep -m 1 "White-listed players:")
-=======
-get_script_location() {
-	echo $(dirname "$(readlink -e "$0")")
+	
+    echo
+    echo "Currently there are the following players on your whitelist:"
+    echo
+    echo ${whitelist:49} | sed 's/, /\n/g'
 }
 
->>>>>>> origin/pidfile
-
-	echo
-	echo "Currently there are the following players on your whitelist:"
-	echo
-	echo ${whitelist:49} | sed 's/, /\n/g'
+get_script_location() {
+	echo $(dirname "$(readlink -e "$0")")
 }
 
 case "$1" in

--- a/minecraft
+++ b/minecraft
@@ -48,7 +48,7 @@ as_user() {
 is_running(){
 	# Checks for the minecraft servers screen session
 	# returns true if it exists.
-	pidfile=$(get_script_location)/${SCREEN}.pid
+	pidfile=$(MCPATH)/${SCREEN}.pid
 
 	if [ -r "$pidfile" ]
 	then
@@ -91,7 +91,7 @@ datepath() {
 	fi
 }
 mc_start() {
-	pidfile=$(get_script_location)/${SCREEN}.pid
+	pidfile=$(MCPATH)/${SCREEN}.pid
 
 	as_user "cd $MCPATH && screen -dmS $SCREEN $INVOCATION"
 	as_user "echo $(screen -list | grep $SCREEN | cut -f1 -d'.' | sed 's/\W//g') > $pidfile"
@@ -160,7 +160,7 @@ mc_say() {
 }
 
 mc_stop() {
-	pidfile=$(get_script_location)/${SCREEN}.pid
+	pidfile=$(MCPATH)/${SCREEN}.pid
 	#
 	# Stops the server
 	#

--- a/minecraft
+++ b/minecraft
@@ -53,7 +53,7 @@ is_running(){
 	if [ -r "$pidfile" ]
 	then
 		pid=$(cat $pidfile)
-		if ps ax | grep -v grep | grep ${pid} | grep "${SCREEN} ${INVOCATION}" > /dev/null
+		if ps ax | grep -v grep | grep ${pid} | grep "${SCREEN}" > /dev/null
 		then
 			return 0
 		else 

--- a/minecraft
+++ b/minecraft
@@ -48,7 +48,7 @@ as_user() {
 is_running(){
 	# Checks for the minecraft servers screen session
 	# returns true if it exists.
-	pidfile=$(MCPATH)/${SCREEN}.pid
+	pidfile=${MCPATH}/${SCREEN}.pid
 
 	if [ -r "$pidfile" ]
 	then
@@ -91,7 +91,7 @@ datepath() {
 	fi
 }
 mc_start() {
-	pidfile=$(MCPATH)/${SCREEN}.pid
+	pidfile=${MCPATH}/${SCREEN}.pid
 
 	as_user "cd $MCPATH && screen -dmS $SCREEN $INVOCATION"
 	as_user "echo $(screen -list | grep $SCREEN | cut -f1 -d'.' | sed 's/\W//g') > $pidfile"
@@ -160,7 +160,7 @@ mc_say() {
 }
 
 mc_stop() {
-	pidfile=$(MCPATH)/${SCREEN}.pid
+	pidfile=${MCPATH}/${SCREEN}.pid
 	#
 	# Stops the server
 	#


### PR DESCRIPTION
This creates a pid-file in $MCPATH, so the minecraft server can be observed with tools like [monit](http://mmonit.com/monit/). Also the `ps ax` check, whether the server is running or not, is less strict, as long as there is a valid pid-file.
As a result, you now can modify the invocation in the config file during runtime and restart the server without screwing things up. ;)

**Edit:**
The commit log looks kinda weird, because i did some crazy merging, but the diff view looks fine.
