### PR TITLE
Delete invalids links

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -299,6 +299,7 @@ check_links() {
 		if [[ -L $MCPATH/${WORLDNAME[$INDEX]} || ! -a $MCPATH/${WORLDNAME[$INDEX]} ]]
 		then
 			link=`ls -l $MCPATH/${WORLDNAME[$INDEX]} | awk '{print $11}'`
+			as_user "find -L $MCPATH -type l -delete"
 			if ${WORLDRAM[$INDEX]}
 			then
 				if [ "$link" != "$RAMDISK/${WORLDNAME[$INDEX]}" ]


### PR DESCRIPTION
My plugin create world and destroy them after a certain time, this modification is needed to clean the MCPATH from this obsolet worlds.

I added a checkLink in the "world backup" routine, cause for the same reason, some worlds are created while the server is running, I dont add this change in this pull, cause I assume its an personnal adjustment :D, but you could add too cause some plugins use creation on the fly too (multiverse-like).
