### PR TITLE
Added a feature to send a command.

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -727,9 +727,19 @@ case "$1" in
 	say)
 		# Says something to the ingame chat
 		if is_running; then
-			mc_say "$2"
+			shift 1
+			mc_say "$*"
 		else
 			echo "No running server to say anything."
+		fi
+		;;
+	command)
+		if is_running; then
+			shift 1
+			mc_command "$*"
+			echo "Sent command: $*"
+		else
+			echo "No running server to send a command to."
 		fi
 		;;
 	connected)


### PR DESCRIPTION
Adds a feature to send a command.

Additionally I changed the syntax of the "say" command (notice the missing quotation marks):

```
root@v166:/etc/minecraft-init/minecraft say your text
Said: your text
```

The syntax is backwardscompatible with the old syntax.
The added command-Subcommand works in the same way.
