### PR TITLE
Log roll

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -207,6 +207,34 @@ mc_stop() {
 	echo "$SERVICE is now shut down."
 }
 
+log_roll() {
+	# Moves and Gzips the logfiles into a directory
+	shopt -s extglob
+	path=`datepath $LOGPATH/logs_`
+	as_user "mkdir -p $path"
+	
+	for FILE in $(ls $MCPATH/*.log)
+	do
+		as_user "cp $FILE $path"
+		# only if previous command was successful
+		if [ $? -eq 0 ]; then
+			if [[ "$FILE" = @(*-+([0-9]).log) && "$FILE" = !(*-0.log) ]]
+			# some mods already roll logs. remove all but the most recent file
+			# which ends with -0.log
+			then
+				as_user "rm $FILE"
+			else
+			# truncate the existing log without restarting server
+				as_user "cp /dev/null $FILE"
+				as_user "echo \"Previous logs rolled to $path\" > $FILE"
+			fi
+		else    
+			echo "Failed to rotate log from $FILE into $path"
+		fi
+	done
+	as_user "gzip -r $path"
+}
+
 get_worlds() {
 	SAVEIFS=$IFS
 	IFS=$(echo -en "\n\b")
@@ -755,20 +783,7 @@ case "$1" in
 		fi
 		;;
 	log-roll)
-		# Moves and Gzips the logfile
-		if [ ! -d $LOGPATH ]; then
-			as_user "mkdir -p $LOGPATH"
-		fi
-		path=`datepath $LOGPATH/server_ .log.gz .log`
-		as_user "cp $MCPATH/server.log $path && gzip $path"
-		# only if previous command was successful
-		if [ $? -eq 0 ]; then
-			# turnacate the existing log without restarting server
-			as_user "cp /dev/null $MCPATH/server.log"
-			as_user "echo \"Previous logs rolled to $path\" > $MCPATH/server.log "
-		else    
-			echo "Failed to rotate logs to $LOGPATH/server_$path.log.gz"
-		fi
+		log_roll
 		;;
 	last)
 		# Greps for recently logged in users

--- a/minecraft
+++ b/minecraft
@@ -45,7 +45,7 @@ as_user() {
 	fi
 }
 
-is_running(){
+is_running() {
 	# Checks for the minecraft servers screen session
 	# returns true if it exists.
 	pidfile=${MCPATH}/${SCREEN}.pid
@@ -129,12 +129,12 @@ mc_start() {
 }
 
 mc_command() {
-		if is_running
-		then
-				as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"$(eval echo $FORMAT)\"\015'"
-		else
-				echo "$SERVICE was not running. Not able to run command."
-		fi
+	if is_running
+	then
+			as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"$(eval echo $FORMAT)\"\015'"
+	else
+			echo "$SERVICE was not running. Not able to run command."
+	fi
 }
 
 mc_saveoff() {
@@ -265,13 +265,15 @@ mc_world_backup() {
 	get_worlds
 	today="`date +%F`"
 	as_user "mkdir -p $BACKUPPATH"
-	# Check if the backupt script compatibility is enabled
-		if [ "$BACKUPSCRIPTCOMPATIBLE" ]
-		then
-			# If it is enabled, then delete the old backups to prevent errors
-			echo "Detected that backup script compatibility is enabled, deleting old backups that are not necessary."
-			as_user "rm -r $BACKUPPATH/*"
-		fi
+	
+	# Check if the backup script compatibility is enabled
+	if [ "$BACKUPSCRIPTCOMPATIBLE" ]
+	then
+		# If it is enabled, then delete the old backups to prevent errors
+		echo "Detected that backup script compatibility is enabled, deleting old backups that are not necessary."
+		as_user "rm -r $BACKUPPATH/*"
+	fi
+	
 	for INDEX in ${!WORLDNAME[@]}
 	do
 		echo "Backing up minecraft ${WORLDNAME[$INDEX]}"
@@ -665,7 +667,7 @@ case "$1" in
 		fi
 		;;
 	whole-backup)
-				# Backup everything
+		# Backup everything
 		if is_running; then
 			mc_say "COMPLETE SERVER BACKUP IN 10 SECONDS.";
 			mc_say "WARNING: WILL RESTART SERVER SOFTWARE!"

--- a/minecraft
+++ b/minecraft
@@ -207,12 +207,31 @@ mc_stop() {
 	echo "$SERVICE is now shut down."
 }
 
+check_backup_settings() {
+	case "$BACKUPFORMAT" in
+		tar)
+			COMPRESSCMD="tar -hcjf"
+			STORECMD="tar -cpf"
+			ARCHIVEENDING=".tar.bz2"
+			;;
+		zip)
+			COMPRESSCMD="zip -rq"
+			STORECMD="zip -rq -0"
+			ARCHIVEENDING=".zip"
+			;;
+		*)
+			echo "$BACKUPFORMAT is not a supported backup format"
+			exit 1
+			;;
+}
+
 log_roll() {
-	# Moves and Gzips the logfiles into a directory
-	shopt -s extglob
-	path=`datepath $LOGPATH/logs_`
+	# Moves the logfiles and compresses that backup directory
+	check_backup_settings
+	path=`datepath $LOGPATH/logs_ $ARCHIVEENDING`
 	as_user "mkdir -p $path"
-	
+
+	shopt -s extglob
 	for FILE in $(ls $MCPATH/*.log)
 	do
 		as_user "cp $FILE $path"
@@ -232,7 +251,11 @@ log_roll() {
 			echo "Failed to rotate log from $FILE into $path"
 		fi
 	done
-	as_user "gzip -r $path"
+
+	as_user "$COMPRESSCMD $path$ARCHIVEENDING $path"
+	if [ $? -eq 0 ]; then
+		as_user "rm -r $path"
+	fi
 }
 
 get_worlds() {


### PR DESCRIPTION
Some mods use their own log file. Some even implement rolling logs themself, storing them with a dash and number sufix in the file name. Among such files only the "-0" file needs to be truncated.

If there were a specific reason for using gzip then drop the last commit of the request. It implement using tar.gz or zip as indicated in the config file.
