### PR TITLE
Fix STORECMD: command not found

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -303,7 +303,7 @@ mc_whole_backup() {
 	then
 		as_user "$COMPRESSCMD $path/whole-backup$ARCHIVEENDING $MCPATH $exclude"
 	else
-		as_user "STORECMD $path/whole-backup$STOREDENDING $MCPATH $exclude"
+		as_user "$STORECMD $path/whole-backup$STOREDENDING $MCPATH $exclude"
 	fi
 }
 


### PR DESCRIPTION
If COMPRESS_WHOLEBACKUP is undefined there is an error:

```
bash: STORECMD: command not found
```
