### PR TITLE
Fix 'connected' command for Minecraft/Bukkit 1.6.2.

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -773,8 +773,22 @@ case "$1" in
 		# Lists connected users
 		if is_running; then
 			mc_command list
-			sleep 3s
-			tac $MCPATH/server.log | grep -m 1 "Connected"
+			sleep 1s
+			# Get server log in reverse order, assume that response to 'list'
+			# command is already there.
+			tac $MCPATH/server.log | \
+				# Extract two lines. 1) containing ASCII color code and comma-separated list
+				# of  player names and 2) the line saying "[...] players online:"
+				grep --before-context 1 --max-count 1 "players online" | \
+				# Throw away the latter line.
+				head -n 1 | \
+				# Remove any escape character and the following two bytes (color code).
+				sed 's/[\x01-\x1F\x7F]..//g' | \
+				# Only pass through lines that still have content (if no player online,
+				# then nothing's left over after this grep.
+				grep . | \
+				# Replace ", " separator with newline char.
+				sed 's/, /\n/g'
 		else
 			echo "No running server."
 		fi


### PR DESCRIPTION
According to issue #123, the 'connected' command is broken as of Minecraft (Bukkit) 1.6.2. This commit solves the problem in the following way:

Input log in reverse direction to grep, search for first appearance of "players online", forward this line and the line before. The line before is contains a `", "`-separated list of connected players. Ouput each player name on its own line and properly deal with color ASCII codes.

Also, a delay of three seconds before evaluating the log file seems to be over the top. The server should immediately return the answer and write to the log file, so I believe that one second of delay is safe enough.
