### PR TITLE
added check for the existence of the service jar 

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -101,6 +101,13 @@ datepath() {
 }
 
 mc_start() {
+	servicejar=$MCPATH/$SERVICE
+	if [ ! -f "$servicejar" ]
+	then
+		echo "Failed to start: Can't find the specified Minecraft jar under $servicejar. Please check your config!"
+		exit 1
+	fi
+
 	pidfile=${MCPATH}/${SCREEN}.pid
 	check_permissions
 


### PR DESCRIPTION
and understandable error on fail.

I installed the script on my server and had a hard time finding the error i did by not writing the correct name of the jar in the config file.

So I added a check to the script that will give the user a error message if the file doesn't exist.
