### PR TITLE
Avoid corrupting pid file when screen -list resturns extra lines

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -112,7 +112,7 @@ mc_start() {
 	check_permissions
 
 	as_user "cd $MCPATH && screen -dmS $SCREEN $INVOCATION"
-	as_user "screen -list | grep "\.$SCREEN" | cut -f1 -d'.' | tr -d -c 0-9 > $pidfile"
+	as_user "screen -list | grep "\.$SCREEN" | cut -f1 -d'.' | head -n 1 | tr -d -c 0-9 > $pidfile"
 
 	#
 	# Waiting for the server to start


### PR DESCRIPTION
My screen -list command return one extra line like
"1 socket[...]/S-minecraft"
Because grep catch "minecraft", this line is kept and "1" is appended to the real pid !
Piping with "head -n 1" and it's done.
