### PR TITLE
Add spigot support, add dynamic path to server logs, correct a variable

### DIFF
--- a/config.example
+++ b/config.example
@@ -7,8 +7,11 @@
 # and edit the variables to your needs.
 #
 
-# Name of vanilla server jar (no need to change if you're running craftbukkit and vice versa)
+# Name of vanilla server jar (no need to change if you're running craftbukkit or spigot and vice versa)
 MC_JAR="minecraft_server.jar"
+
+# Name of spigot jar
+SP_JAR="spigot.jar"
 
 # Name of craftbukkit jar 
 CB_JAR="craftbukkit.jar"
@@ -27,6 +30,9 @@ USERNAME="minecraft"
 
 # Path to minecraft server directory 
 MCPATH="/home/${USERNAME}/minecraft"
+
+# Path to the server log file ($MCPATH/server.log on older versions)
+SERVERLOG="${MCPATH}/logs/latest.log"
 
 # Where the worlds are located on the disk. Can not be the same as MCPATH.
 # You need to move your worlds to this directory manually, the script
@@ -121,7 +127,7 @@ OVBACKUP="/home/${USERNAME}/mc-overviewer/overviewerbackups"
 # Things to leave alone ;)
 # =====================
 
-INVOCATION="java -Xmx$MAXMEM -Xms$INITMEM -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalPacing -XX:ParallelGCThreads=$CPU_COUNT -XX:+AggressiveOpts -jar $SERVICE nogui"
+INVOCATION="java -XX:MaxPermSize=256M -Xmx$MAXMEM -Xms$INITMEM -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalPacing -XX:ParallelGCThreads=$CPU_COUNT -XX:+AggressiveOpts -jar $SERVICE nogui"
 
 # Path to the the mounted ramdisk (the default will work in most senarios).
 RAMDISK="/dev/shm"

--- a/minecraft
+++ b/minecraft
@@ -525,7 +525,7 @@ mc_update() {
 			fi
 		else
 			echo "Not updating $SP_JAR. It's not necessary"
-			as_user "rm $MCPATH/minecraft_server.jar.update"
+			as_user "rm $MCPATH/spigot.jar.update"
 		fi
 
 		if check_update_craftbukkit

--- a/minecraft
+++ b/minecraft
@@ -869,8 +869,8 @@ case "$1" in
 		log_roll
 		;;
 	log)
-		# Display server log using 'cat'.
-		cat $SERVERLOG
+		# Display server log using tac & more.
+		tac $SERVERLOG | more
 		;;
 	last)
 		# Greps for recently logged in users
@@ -990,7 +990,7 @@ case "$1" in
 		echo -e "   reload \t\t Reloads the server plugins"
 		echo -e "   backup \t\t Backups the worlds defined in the script"
 		echo -e "   whole-backup \t Backups the entire server folder"
-		echo -e "   check-update \t Checks for updates of $CB_JAR and $MC_JAR"
+		echo -e "   check-update \t Checks for updates of $CB_JAR, $SP_JAR, and $MC_JAR"
 		echo -e "   update \t\t Fetches the latest version of minecraft.jar server and Bukkit"
 		echo -e "   log-roll \t\t Moves and compresses the logfiles"
 		echo -e "   log \t\t\t Prints the server log"

--- a/minecraft
+++ b/minecraft
@@ -251,35 +251,39 @@ check_backup_settings() {
 }
 
 log_roll() {
-	# Moves the logfiles and compresses that backup directory
-	check_backup_settings
-	path=`datepath $LOGPATH/logs_ $ARCHIVEENDING`
-	as_user "mkdir -p $path"
-
-	shopt -s extglob
-	for FILE in $(ls $MCPATH/*.log)
-	do
-		as_user "cp $FILE $path"
-		# only if previous command was successful
-		if [ $? -eq 0 ]; then
-			if [[ "$FILE" = @(*-+([0-9]).log) && "$FILE" = !(*-0.log) ]]
-			# some mods already roll logs. remove all but the most recent file
-			# which ends with -0.log
-			then
-				as_user "rm $FILE"
+	if [ ! -f $MCPATH/*.log ]; then
+		# Moves the logfiles and compresses that backup directory
+		check_backup_settings
+		path=`datepath $LOGPATH/logs_ $ARCHIVEENDING`
+		as_user "mkdir -p $path"
+	
+		shopt -s extglob
+		for FILE in $(ls $MCPATH/*.log)
+		do
+			as_user "cp $FILE $path"
+			# only if previous command was successful
+			if [ $? -eq 0 ]; then
+				if [[ "$FILE" = @(*-+([0-9]).log) && "$FILE" = !(*-0.log) ]]
+				# some mods already roll logs. remove all but the most recent file
+				# which ends with -0.log
+				then
+					as_user "rm $FILE"
+				else
+				# truncate the existing log without restarting server
+					as_user "cp /dev/null $FILE"
+					as_user "echo \"Previous logs rolled to $path\" > $FILE"
+				fi
 			else
-			# truncate the existing log without restarting server
-				as_user "cp /dev/null $FILE"
-				as_user "echo \"Previous logs rolled to $path\" > $FILE"
+				echo "Failed to rotate log from $FILE into $path"
 			fi
-		else
-			echo "Failed to rotate log from $FILE into $path"
+		done
+	
+		as_user "$COMPRESSCMD $path$ARCHIVEENDING $path"
+		if [ $? -eq 0 ]; then
+			as_user "rm -r $path"
 		fi
-	done
-
-	as_user "$COMPRESSCMD $path$ARCHIVEENDING $path"
-	if [ $? -eq 0 ]; then
-		as_user "rm -r $path"
+	else
+		echo "Logs are already rolled to \"$MCPATH/logs\".".
 	fi
 }
 

--- a/minecraft
+++ b/minecraft
@@ -145,6 +145,18 @@ mc_command() {
 	fi
 }
 
+mc_reload() {
+	if is_running
+	then
+		echo "$SERVICE is running... reloading plugins
+		mc_say Reloading Plugins
+		mc_command reload
+		mc_say Reload Complete.
+	else
+		echo "$SERVICE is not running."
+	fi
+}
+
 mc_saveoff() {
 	if is_running
 	then
@@ -971,6 +983,7 @@ case "$1" in
 		echo -e "   stop \t\t Stops the server"
 		echo -e "   kill \t\t Kills the server"
 		echo -e "   restart \t\t Restarts the server"
+		echo -e "   reload \t\t Reloads the server plugins"
 		echo -e "   backup \t\t Backups the worlds defined in the script"
 		echo -e "   whole-backup \t Backups the entire server folder"
 		echo -e "   check-update \t Checks for updates of $CB_JAR and $MC_JAR"

--- a/minecraft
+++ b/minecraft
@@ -478,11 +478,11 @@ check_update_craftbukkit() {
 
 check_update_spigot() {
 	echo "Checking for update for spigot.jar"
-	as_user "cd $MCPATH && wget -q -O $MCPATH/minecraft_server.jar.update http://ci.md-5.net/job/Spigot/lastSuccessfulBuild/artifact/Spigot-Server/target/spigot.jar"
+	as_user "cd $MCPATH && wget -q -O $MCPATH/spigot.jar.update http://ci.md-5.net/job/Spigot/lastSuccessfulBuild/artifact/Spigot-Server/target/spigot.jar"
 
 	if [ -r "$MCPATH/spigot.jar.update" ]
 	then
-		if `diff $MCPATH/$MC_JAR $MCPATH/spigot.jar.update >/dev/null`
+		if `diff $MCPATH/$SP_JAR $MCPATH/spigot.jar.update >/dev/null`
 		then
 			echo "You are already running the latest version of spigot.jar."
 			return 1
@@ -491,7 +491,7 @@ check_update_spigot() {
 			return 0
 		fi
 	else
-		echo "Something went wrong. Couldn't download minecraft_server.jar"
+		echo "Something went wrong. Couldn't download spigot.jar"
 	fi
 }
 

--- a/minecraft
+++ b/minecraft
@@ -251,7 +251,7 @@ check_backup_settings() {
 }
 
 log_roll() {
-	if [ ! -f $MCPATH/*.log ]; then
+	if [ ! -f $MCPATH/logs/latest.log ]; then
 		# Moves the logfiles and compresses that backup directory
 		check_backup_settings
 		path=`datepath $LOGPATH/logs_ $ARCHIVEENDING`

--- a/minecraft
+++ b/minecraft
@@ -148,7 +148,7 @@ mc_command() {
 mc_reload() {
 	if is_running
 	then
-		echo "$SERVICE is running... reloading plugins
+		echo "$SERVICE is running... reloading plugins."
 		mc_say Reloading Plugins
 		mc_command reload
 		mc_say Reload Complete.

--- a/minecraft
+++ b/minecraft
@@ -19,6 +19,7 @@
 # Support for multiworld by Benni-chan
 # Log rolls without needing restarts by Solorvox
 # Option for killing server in an emergency by jbondhus
+# Spigot support by alfonsojon
 
 # Loads config file
 
@@ -475,6 +476,25 @@ check_update_craftbukkit() {
 	fi
 }
 
+check_update_spigot() {
+	echo "Checking for update for spigot.jar"
+	as_user "cd $MCPATH && wget -q -O $MCPATH/minecraft_server.jar.update http://ci.md-5.net/job/Spigot/lastSuccessfulBuild/artifact/Spigot-Server/target/spigot.jar"
+
+	if [ -r "$MCPATH/spigot.jar.update" ]
+	then
+		if `diff $MCPATH/$MC_JAR $MCPATH/spigot.jar.update >/dev/null`
+		then
+			echo "You are already running the latest version of spigot.jar."
+			return 1
+		else
+			echo "Update of $SP_JAR is needed."
+			return 0
+		fi
+	else
+		echo "Something went wrong. Couldn't download minecraft_server.jar"
+	fi
+}
+
 mc_update() {
 	if is_running
 	then
@@ -490,7 +510,21 @@ mc_update() {
 				echo "Something went wrong. Couldn't replace your original $MC_JAR with minecraft_server.jar.update"
 			fi
 		else
-			echo "Not updating $MB_JAR. It's not necessary"
+			echo "Not updating $MC_JAR. It's not necessary"
+			as_user "rm $MCPATH/minecraft_server.jar.update"
+		fi
+
+		if check_update_spigot
+		then
+			if [ -r "$MCPATH/spigot.jar.update" ]
+			then
+				as_user "mv $MCPATH/spigot.update $MCPATH/$SP_JAR"
+				echo "Thats it. Update of $SP_JAR done."
+			else
+				echo "Something went wrong. Couldn't replace your original $SP_JAR with spigot.jar.update"
+			fi
+		else
+			echo "Not updating $SP_JAR. It's not necessary"
 			as_user "rm $MCPATH/minecraft_server.jar.update"
 		fi
 
@@ -588,7 +622,7 @@ overviewer_copy_worlds() {
 whitelist(){
 	mc_command "whitelist list"
 	sleep 1s
-	whitelist=$(tac $MCPATH/server.log | grep -m 1 "White-listed players:")
+	whitelist=$(tac $SERVERLOG | grep -m 1 "White-listed players:")
 
 	echo
 	echo "Currently there are the following players on your whitelist:"
@@ -715,8 +749,10 @@ case "$1" in
 	check-update)
 		check_update_vanilla
 		check_update_craftbukkit
+		check_update_spigot
 		as_user "rm $MCPATH/minecraft_server.jar.update"
 		as_user "rm $MCPATH/craftbukkit.jar.update"
+		as_user "rm $MCPATH/spigot.jar.update"
 		;;
 	update)
 		#update minecraft_server.jar and craftbukkit.jar (thanks karrth)
@@ -783,7 +819,7 @@ case "$1" in
 			sleep 1s
 			# Get server log in reverse order, assume that response to 'list'
 			# command is already there.
-			tac $MCPATH/server.log | \
+			tac $SERVERLOG | \
 				# Extract two lines. 1) containing ASCII color code and comma-separated list
 				# of  player names and 2) the line saying "[...] players online:"
 				grep --before-context 1 --max-count 1 "players online" | \
@@ -806,7 +842,7 @@ case "$1" in
 			mc_command list
 			sleep 1s
 			# Same as technique as 'connected' command, but count lines.
-			tac $MCPATH/server.log | \
+			tac $SERVERLOG | \
 				grep --before-context 1 --max-count 1 "players online" | \
 				head -n 1 | sed 's/[\x01-\x1F\x7F]..//g' | grep . | sed 's/, /\n/g' | wc -l
 		else
@@ -818,12 +854,12 @@ case "$1" in
 		;;
 	log)
 		# Display server log using 'cat'.
-		cat $MCPATH/server.log
+		cat $SERVERLOG
 		;;
 	last)
 		# Greps for recently logged in users
 		echo Recently logged in users:
-		cat $MCPATH/server.log | awk '/entity|conn/ {sub(/lost/,"disconnected");print $1,$2,$4,$5}'
+		cat $SERVERLOG | awk '/entity|conn/ {sub(/lost/,"disconnected");print $1,$2,$4,$5}'
 		;;
 	status)
 		# Shows server status
@@ -837,7 +873,7 @@ case "$1" in
 	version)
 		if is_running; then
 			mc_command version
-			tac $MCPATH/server.log | grep -m 1 "This server is running"
+			tac $SERVERLOG | grep -m 1 "This server is running"
 		else
 			echo "The server needs to be running to check version."
 		fi

--- a/minecraft
+++ b/minecraft
@@ -283,7 +283,7 @@ log_roll() {
 			as_user "rm -r $path"
 		fi
 	else
-		echo "Logs are already rolled to \"$MCPATH/logs\".".
+		echo "Logs are already rolled to \"$MCPATH/logs\"."
 	fi
 }
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,7 +1,7 @@
-Init script for minecraft/bukkit servers
+Init script for various minecraft servers
 =======================================
 A init script that apart form starting and stopping the server correctly also has some extra features
-for running a mincraft/craftbukkit server.
+for running a mincraft/craftbukkit/spigot server.
 
 Features
 --------


### PR DESCRIPTION
I added spigot support to the server start sequence and the updater. I also merged in a change to allow a dynamic path for server log files (https://github.com/Ahtenus/minecraft-init/pull/157) and fixed some variables.

Also, the -XX:MaxPermSize=256M is there because Bukkit and Spigot tend to crash if that is not present.
