### PR TITLE
Changes to enable minecraft-init to run on OS X

### DIFF
--- a/config.example
+++ b/config.example
@@ -7,6 +7,10 @@
 # and edit the variables to your needs.
 #
 
+# Location of bash shell on your system, by default we grab the first entry
+# from which, however, you can manually set it to whatever you want.
+BASH_PATH=`which bash | cut -f3 -d' ' | sed -n 1p`
+
 # Name of vanilla server jar (no need to change if you're running craftbukkit and vice versa)
 MC_JAR="minecraft_server.jar"
 

--- a/config.example
+++ b/config.example
@@ -26,7 +26,7 @@ SCREEN="server_screen"
 USERNAME="minecraft"
 
 # Path to minecraft server directory 
-MCPATH="/home/${USERNAME}/minecraft"
+MCPATH="${HOME}/minecraft"
 
 # Path to server log file ($MCPATH/server.log on older versions)
 SERVERLOG="${MCPATH}/logs/latest.log"
@@ -54,11 +54,11 @@ FORMAT='$1'
 # ===============================
 
 # Location for world backups
-BACKUPPATH="/home/${USERNAME}/mcbackup/worlds"
+BACKUPPATH="${HOME}/mcbackup/worlds"
 
 # Where the whole minecraft directory is copied when whole-backup is executed
 # whole-backup is a complete uncompressed backup of the whole server folder.
-WHOLEBACKUP="/home/${USERNAME}/mcbackup/server"
+WHOLEBACKUP="${HOME}/mcbackup/server"
 
 # Format for world backup (tar or zip).
 BACKUPFORMAT="tar" 
@@ -93,7 +93,7 @@ COMPRESS_WHOLEBACKUP=YES
 
 # Location for old logs
 # Used by the log-roll command
-LOGPATH="/home/${USERNAME}/mcbackup/logs"
+LOGPATH="${HOME}/mcbackup/logs"
 
 # Whether or not to gzip logs (must be commented out for no - DO NOT CHANGE TO NO)
 #
@@ -107,19 +107,19 @@ LOGFILEAPPEND="logfile_"
 # ===============================
 
 # Where the Map is generated
-OUTPUTMAP="/home/${USERNAME}/mc-overviewer/render"
+OUTPUTMAP="${HOME}/mc-overviewer/render"
 
 # Path to Minecraft-Overviewer
-OVPATH="/home/${USERNAME}/mc-overviewer/Minecraft-Overviewer"
+OVPATH="${HOME}/mc-overviewer/Minecraft-Overviewer"
 
 # Path for the config file of Overviewer
-OVCONFIGPATH="/home/${USERNAME}/mc-overviewer"
+OVCONFIGPATH="${HOME}/mc-overviewer"
 
 # Name of Overviewer config file
 OVCONFIGNAME="config.py"
 
 # Path for backup worlds
-OVBACKUP="/home/${USERNAME}/mc-overviewer/overviewerbackups"
+OVBACKUP="${HOME}/mc-overviewer/overviewerbackups"
 
 # Things to leave alone ;)
 # =====================

--- a/minecraft
+++ b/minecraft
@@ -261,7 +261,7 @@ log_roll() {
 		as_user "cp $FILE $path"
 		# only if previous command was successful
 		if [ $? -eq 0 ]; then
-			if [[ "$FILE" =~ @(*-+([0-9]).log) && "$FILE" =~ !(*-0.log) ]]
+			if [[ "$FILE" = @(*-+([0-9]).log) && "$FILE" = !(*-0.log) ]]
 			# some mods already roll logs. remove all but the most recent file
 			# which ends with -0.log
 			then

--- a/minecraft
+++ b/minecraft
@@ -21,10 +21,16 @@
 # Option for killing server in an emergency by jbondhus
 
 # Loads config file
+OS=`uname`
 
 if [ -L $0 ]
 then
-	source `readlink -e $0 | sed "s:[^/]*$:config:"`
+	if [ "$OS" == "Darwin" ]
+	then
+		source `readlink $0 | sed "s:[^/]*$:config:"`
+	else
+		source `readlink -e $0 | sed "s:[^/]*$:config:"`
+	fi
 else
 	source `echo $0 | sed "s:[^/]*$:config:"`
 fi

--- a/minecraft
+++ b/minecraft
@@ -45,9 +45,9 @@ fi
 ME=`whoami`
 as_user() {
 	if [ $ME == $USERNAME ] ; then
-		bash -c "$1"
+		"$BASH_PATH" -c "$1"
 	else
-		su $USERNAME -s /bin/bash -c "$1"
+		su $USERNAME -s "$BASH_PATH" -c "$1"
 	fi
 }
 

--- a/minecraft
+++ b/minecraft
@@ -255,7 +255,7 @@ log_roll() {
 		as_user "cp $FILE $path"
 		# only if previous command was successful
 		if [ $? -eq 0 ]; then
-			if [[ "$FILE" = @(*-+([0-9]).log) && "$FILE" = !(*-0.log) ]]
+			if [[ "$FILE" =~ @(*-+([0-9]).log) && "$FILE" =~ !(*-0.log) ]]
 			# some mods already roll logs. remove all but the most recent file
 			# which ends with -0.log
 			then

--- a/minecraft
+++ b/minecraft
@@ -35,6 +35,12 @@ else
 	source `echo $0 | sed "s:[^/]*$:config:"`
 fi
 
+# Set bash to default if nothing was set
+if [ "$BASH_PATH" == "" ]
+then
+    BASH_PATH=/bin/bash
+fi
+
 if [ "$SERVICE" == "" ]
 then
 	echo "Couldn't load config file, please edit config.example and rename it to config"


### PR DESCRIPTION
Should be backward-compatible with previous configs. But I often like to download my worlds and run them locally on my mac book and having minecraft-init run both on my Linux server and OS X is convenient.
