### PR TITLE
Properly pass value of $SCREEN to as_user

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -875,7 +875,7 @@ case "$1" in
 		;;
 	screen)
 		if is_running; then
-			as_user 'script /dev/null -q -c "screen -rx $SCREEN"'
+			as_user "script /dev/null -q -c \"screen -rx $SCREEN\""
 		else
 		echo "Server is not running. Do you want to start it?"
 		echo "Please put \"Yes\", or \"No\": "
@@ -885,7 +885,7 @@ case "$1" in
 				check_links
 				to_ram
 				mc_start
-				as_user 'script /dev/null -q -c "screen -rx $SCREEN"'
+				as_user "script /dev/null -q -c \"screen -rx $SCREEN\""
 				;;
 			[Nn]|[Nn][Oo])
 				clear


### PR DESCRIPTION
Now passes the value of the variable rather than the literal '$SCREEN' to the as_user function when user requests the screen command.

(useful when this script is used to manage multiple instances for the same user in which case the screen attached would not necessarily be the one intended as the SCREEN variable was not used properly)
