### PR TITLE
Reload support

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -214,6 +214,16 @@ mc_stop() {
 	echo "$SERVICE is now shut down."
 }
 
+mc_reload() {
+        if ps ax | grep -v grep | grep -v -i SCREEN | grep $SERVICE > /dev/null
+        then
+                echo "$SERVICE is running... reloading."
+                as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"reload\"\015'"
+        else
+                echo "$SERVICE was not running."
+        fi
+}
+
 check_backup_settings() {
 	case "$BACKUPFORMAT" in
 		tar)
@@ -662,6 +672,11 @@ case "$1" in
 		to_ram
 		mc_start
 		;;
+        reload)
+                # Reloads server configuration
+                as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"say Reloading configurations..\"\015'"
+                mc_reload
+                ;;
 	whitelist)
 		if is_running; then
 			whitelist

--- a/minecraft
+++ b/minecraft
@@ -215,13 +215,8 @@ mc_stop() {
 }
 
 mc_reload() {
-        if is_running
-        then
-                echo "$SERVICE is running... reloading."
-                mc_command reload
-        else
-                echo "$SERVICE was not running. Not able to reload anything."
-        fi
+        echo "$SERVICE is running... reloading."
+        mc_command reload
 }
 
 check_backup_settings() {
@@ -674,8 +669,12 @@ case "$1" in
 		;;
         reload)
                 # Reloads server configuration
-                mc_say "Reloading configurations.."
-                mc_reload
+                if is_running; then
+                        mc_say "Reloading server configuration.."
+                        mc_reload
+                else
+                        echo "No running server."
+                fi
                 ;;
 	whitelist)
 		if is_running; then

--- a/minecraft
+++ b/minecraft
@@ -949,6 +949,7 @@ case "$1" in
 		echo -e "   stop \t\t Stops the server"
 		echo -e "   kill \t\t Kills the server"
 		echo -e "   restart \t\t Restarts the server"
+		echo -e "   reload \t\t Reloads the server configuration"
 		echo -e "   backup \t\t Backups the worlds defined in the script"
 		echo -e "   whole-backup \t Backups the entire server folder"
 		echo -e "   check-update \t Checks for updates of $CB_JAR and $MC_JAR"

--- a/minecraft
+++ b/minecraft
@@ -215,12 +215,12 @@ mc_stop() {
 }
 
 mc_reload() {
-        if ps ax | grep -v grep | grep -v -i SCREEN | grep $SERVICE > /dev/null
+        if is_running
         then
                 echo "$SERVICE is running... reloading."
-                as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"reload\"\015'"
+                mc_command reload
         else
-                echo "$SERVICE was not running."
+                echo "$SERVICE was not running. Not able to reload anything."
         fi
 }
 
@@ -674,7 +674,7 @@ case "$1" in
 		;;
         reload)
                 # Reloads server configuration
-                as_user "screen -p 0 -S $SCREEN -X eval 'stuff \"say Reloading configurations..\"\015'"
+                mc_say "Reloading configurations.."
                 mc_reload
                 ;;
 	whitelist)


### PR DESCRIPTION
I wrote this back in 2011 and never submitted a pull request... better late than never!

This changeset adds the ability to reload the server configuration without restarting it. As a supported feature of minecraft server and craftbukkit, this would be an ideal feature to implement.

The original work has been modified to make use of the new screen interface functions, and so should be up to date with the style of the rest of submitted code.
