### PR TITLE
removed unnecessary apt

### DIFF
--- a/config.example
+++ b/config.example
@@ -10,22 +10,22 @@
 # Name of vanilla server jar (no need to change if you're running craftbukkit and vice versa)
 MC_JAR="minecraft_server.jar"
 
-# Name of craftbukkit jar 
+# Name of craftbukkit jar
 CB_JAR="craftbukkit.jar"
 
 # Define the release of CraftBukkit to use (stable or unstable)
 CB_RELEASE="stable"
 
 # Name of server.jar to use (either $MC_JAR or $CB_JAR)
-SERVICE=$CB_JAR
+SERVICE=$MC_JAR
 
 # Name to use for the screen instance
-SCREEN="server_screen"
+SCREEN="minecraft_screen"
 
 # User that should run the server
 USERNAME="minecraft"
 
-# Path to minecraft server directory 
+# Path to minecraft server directory
 MCPATH="/home/${USERNAME}/minecraft"
 
 # Path to server log file ($MCPATH/server.log on older versions)
@@ -61,7 +61,7 @@ BACKUPPATH="/home/${USERNAME}/mcbackup/worlds"
 WHOLEBACKUP="/home/${USERNAME}/mcbackup/server"
 
 # Format for world backup (tar or zip).
-BACKUPFORMAT="tar" 
+BACKUPFORMAT="tar"
 
 # Normally backups will be put in a subfolder to $BACKUPPATH with todays date
 # and the backups themselves will have a timestamp.

--- a/minecraft
+++ b/minecraft
@@ -536,12 +536,12 @@ change_ramdisk_state() {
 overviewer_start() {
 		if [ ! -e $OVPATH/overviewer.py ]
 		then
-				if [ ! "$OVPATH" == "apt" ]
+				if [ ! "$OVPATH" == "" ]
 				then
 						echo "Minecraft-Overviewer is not installed in \"$OVPATH\""
 						exit 1
 				else
-						echo "Using APT repository installed Minecraft-Overviewer"
+						echo "Using existing Minecraft-Overviewer."
 				fi
 		fi
 		if [ ! -e $OUTPUTMAP ]
@@ -551,7 +551,7 @@ overviewer_start() {
 		if [ -e $OVCONFIGPATH/$OVCONFIGNAME ]
 		then
 				echo "Start generating map with Minecraft-Overviewer..."
-				if [ "$OVPATH" == "apt" ]
+				if [ "$OVPATH" == "" ]
 				then
 						as_user "overviewer.py --config=$OVCONFIGPATH/$OVCONFIGNAME"
 				else

--- a/minecraft
+++ b/minecraft
@@ -36,9 +36,8 @@ then
 	exit
 fi
 
-ME=`whoami`
 as_user() {
-	if [ $ME == $USERNAME ] ; then
+	if [ "$(whoami)" == "$USERNAME" ] ; then
 		bash -c "$1"
 	else
 		su $USERNAME -s /bin/bash -c "$1"


### PR DESCRIPTION
When replacing $OVPATH in the config with nothing it runs the system
installed minecraft overviewer. More logical than putting ”apt” there
to get it to work.
