### PR TITLE
Start minecraft later in the boot process

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -3,7 +3,7 @@
 
 ### BEGIN INIT INFO
 # Provides:   minecraft
-# Required-Start: $local_fs $remote_fs
+# Required-Start: $local_fs $remote_fs $all
 # Required-Stop:  $local_fs $remote_fs
 # Should-Start:   $network
 # Should-Stop:    $network


### PR DESCRIPTION
The script requires /var/run to exist, and in newer distributions that directory does not get created until udev is started, which is usually after $local_fs and $remote_fs. It is perfectly acceptable to start this server after everything else has been started.
